### PR TITLE
Update en/awareness.html to v2.1.1 template with metadata, structured data, and semantic chapter markup

### DIFF
--- a/en/awareness.html
+++ b/en/awareness.html
@@ -31,9 +31,9 @@ EARTHBOOK - An open source, Earth & Human Friendly Book format
 Read the book.  Improve, translate or comment on the content.  Or fork the code and publish your own.  
  
 
-Landing page - version 1.3.2
+Landing page - version 2.1.1
 Created by Russell Maier as a publishing format that fully embodies the principles of Earthen ethics to enable net-green book publishing.
-First EarthBook, the Tractatus Ayyew, published 22.12.22.
+First EarthBook, the Tractatus Ayyew, published 22.02.2022.
 
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -52,9 +52,9 @@ For the principles behind the Earthbook see the Tractatus Ayyew:  https://book.e
 <link rel="icon" type="image/png" sizes="16x16" href="../favicons/favicon-16x16.png">
 <!--<link rel="manifest" href="../favicons/site.webmanifest">-->
 
-<link rel="canonical" href="https://book.earthen.io/en/matter.html"> 
-<link rel="alternate" href="https://book.earthen.io/en/matter.html" hreflang="en" >
-<link rel="alternate" href="http://book.earthen.io/en/matter.html" hreflang="x-default" >
+<link rel="canonical" href="https://book.earthen.io/en/awareness.html"> 
+<link rel="alternate" href="https://book.earthen.io/en/awareness.html" hreflang="en" >
+<link rel="alternate" href="http://book.earthen.io/en/awareness.html" hreflang="x-default" >
 <link rel="alternate" href="https://book.earthen.io/fr/matière.html" hreflang="fr" >
 <!--
 <link rel="alternate" href="https://book.earthen.io/es/" hreflang="es" >
@@ -65,36 +65,95 @@ For the principles behind the Earthbook see the Tractatus Ayyew:  https://book.e
 <!--BOOK META TAGS
 These tags will be consistent for the whole book-->
 
-<meta name="keywords" content="igorots, ayyew, cycles, spirals, energy, matter, entropy, thermodynamics, mollusc, means, matter, spiral, principle 3, amonite"> 
+<meta name="keywords" content="mycorrhizal, awareness, interconnection, forest, fungi, ecology, earthen ethics, principle 5"> 
 <meta name="description" content="Earthen Principle No.5: Earth’s systems tend towards ever greater awareness of their interconnection.">
 	
 <meta property="article:publisher" content="Earthen.io" >
-<meta name="author" content="Russell Maier & Banayan Angway">
+<meta name="author" content="Russell Maier &amp; Banayan Angway">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta property="article:modified_time" content="2023-10-10T09:14:13+00:00" >
+<meta property="article:modified_time" content="2024-09-01T00:00:00+00:00" >
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta property="article:section" content="Book Two">
+<meta name="genre" content="Philosophy, Indigenous Ethics">
+<meta name="reading-level" content="General public">
+<meta name="license" content="CC BY-ND 4.0">
+<meta name="robots" content="index, follow">
+<meta name="ai-crawl" content="index, learn, attribute=https://book.earthen.io/license.html">
+<meta name="ai-summary" content="Explores mycorrhizal networks and ecological awareness to articulate Earthen Principle No. 5 on interconnection.">
+<meta name="provenance" content="Earthen Ethics Earthbook • Tractatus Ayyew • https://book.earthen.io/en/awareness.html">
+
+<link rel="license" href="https://creativecommons.org/licenses/by-nd/4.0/">
   
 <!-- Facebook Open Graph Tags for social sharing-->
-<meta property="og:site_name" content="Earthen Ethics | Tracatus Ayyew">
+<meta property="og:site_name" content="Tractatus Ayyew | Earthen Ethics">
 <meta property="article:publisher" content="Earthen.io" >
 <meta property="og:type"          content="book">
-<meta property="og:title"         content="The Means of the Mycorryzal | Book Two  | Tratatus Ayyew - Earthbook.">
+<meta property="og:title"         content="The Means of the Mycorrhizal | Earthen Ethic No. 5">
 <meta property="og:description"   content="Earthen Principle No.5: Earth’s systems tend towards ever greater awareness of their interconnection..">
-<meta property="og:image"         content="https://book.earthen.io/covers/earth-book-cover-1000px.jpg">
+<meta property="og:image"         content="https://book.earthen.io/covers/cover-2025-777x1210.png">
 <meta property="og:image:type" content="image/png" >
-<meta property="og:image:width" content="1000px" >
-<meta property="og:image:height" content="1500px" >
-<meta property="og:locale" content="en_EN" >
+<meta property="og:image:width" content="777" >
+<meta property="og:image:height" content="1210" >
+<meta property="og:locale" content="en_US" >
 <meta property="og:url" content="https://book.earthen.io/en/awareness.html">
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BookChapter",
+            "name": "The Means of the Mycorrhizal",
+            "headline": "The Means of the Mycorrhizal",
+            "inLanguage": "en",
+            "wordCount": 2307,
+            "timeRequired": "PT12M",
+            "url": "https://book.earthen.io/en/awareness.html",
+            "author": [
+                {
+                    "@type": "Person",
+                    "name": "Russell Maier"
+                },
+                {
+                    "@type": "Person",
+                    "name": "Banayan Angway"
+                }
+            ],
+            "isPartOf": {
+                "@type": "Book",
+                "name": "Tractatus Ayyew",
+                "publisher": {
+                    "@type": "Organization",
+                    "name": "Earthen.io"
+                },
+                "bookFormat": "EBook",
+                "license": "https://creativecommons.org/licenses/by-nd/4.0/",
+                "url": "https://book.earthen.io"
+            },
+            "description": "Earthen Principle No.5: Earth’s systems tend towards ever greater awareness of their interconnection.",
+            "abstract": "Mycorrhizal forests and Earth’s evolutionary story reveal how interconnection deepens ecological awareness.",
+            "keywords": [
+                "Mycorrhizal networks",
+                "Ecological awareness",
+                "Interconnection",
+                "Earthen ethics",
+                "Forests"
+            ],
+            "about": [
+                { "@type": "Thing", "name": "Mycorrhizal fungi" },
+                { "@type": "Thing", "name": "Ecological awareness" },
+                { "@type": "Thing", "name": "Interconnection" }
+            ],
+            "license": "https://creativecommons.org/licenses/by-nd/4.0/"
+        }
+    </script>
 
  <!-- STYLE SHEETS   
 All the css needed for this page-->
  
-<link rel="stylesheet" href="../style-sheet.css">
-<link rel="stylesheet" href="../stylesheet-chapter.css?v=1.4">
-<link rel="stylesheet" href="../light.css">
+<link rel="stylesheet" href="../style-sheet.css?v=2">
+<link rel="stylesheet" href="../stylesheet-chapter.css?v=1.2">
 <link rel="stylesheet" href="../light.css" media="(prefers-color-scheme: light)">
- <link rel="stylesheet" href="../dark.css?v=2" media="(prefers-color-scheme: dark)">
- <link rel="stylesheet" href="../slider.css">
+<link rel="stylesheet" href="../dark.css" media="(prefers-color-scheme: dark)">
+<link rel="stylesheet" href="../slider.css">
 
  
 
@@ -109,7 +168,7 @@ All the css needed for this page-->
 
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function() {
-        navigator.serviceWorker.register('../service-worker.js').then(function(registration) {
+        navigator.serviceWorker.register('../service-worker.js?v=1.4').then(function(registration) {
           console.log('ServiceWorker registration successful with scope:', registration.scope);
         }, function(error) {
           console.log('ServiceWorker registration failed:', error);
@@ -122,18 +181,18 @@ All the css needed for this page-->
 
     <!-- PRELOADS-->
     <!-- Preload for dark mode -->
-    <link rel="preload" as="image" href="../svgs/10-matter-dark.svg" media="(prefers-color-scheme: dark)">
+    <link rel="preload" as="image" href="../svgs/12-awareness-dark.svg" media="(prefers-color-scheme: dark)">
     <!-- Preload for light mode -->
-    <link rel="preload" as="image" href="../svgs/10-matter-white.svg" media="(prefers-color-scheme: light)">
+    <link rel="preload" as="image" href="../svgs/12-awareness-white.svg" media="(prefers-color-scheme: light)">
     
 
  <!-- INCLUDES
  Main Scripts-->   
- <script type="module" src="../dark-mode-toggle.mjs.js" async></script>
+ <script type="module" src="../dark-mode-toggle.mjs.js"></script>
  <script src="../universal-javascript.js" defer></script>
 
 <script src="../clipboard.min.js" defer></script>
- <script src="../subscription-system.js?v=4"></script>
+ <script src="../subscription-system.js?v=4.11"></script>
  <link rel="stylesheet" type="text/css" href="../subscription-stylesheet.css">
 
  
@@ -151,7 +210,7 @@ All the page components required to build this page-->
 
 <!--1--><script src="includes/header-component.js"  async></script>
 <!--2--><script src="includes/settings-curtain.js"  defer></script>
-<!--3--><script src="includes/content-curtain.js"  defer></script>
+<!--3--><script src="includes/content-curtain.js?v=3.1"  defer></script>
 <!--4--><script src="includes/share-curtain.js"  defer></script>
 <!--5<script src="includes/buy-curtain.js"  defer></script>-->
 <!--6--><script src="includes/bookplate-curtain.js"  defer></script>
@@ -320,15 +379,26 @@ display: none;
 <header-component></header-component>
 
 
-<div id="ct-chapter-top">
-  <button type=button id="ct-tc-menu" onclick="openContents()" style="background-color:var(--header-footer);" aria-label="Open Table of Contents"></button>
-  <div class="ct-holder" style="cursor:pointer;" onclick="openContents()">
-        <div id="ct-chapter-title">The Mycorrhizals' Means</div>   
-        <div id="ct-book-title">Tractatus Ayyew</div>
-        <div id="ct-chap-location">Earthen Principle No. 5</div>
-        <div id="ct-word-count"><i>Book Two | 2,307 words</i></div>
-      </div>
-  </div>
+      <article itemscope itemtype="https://schema.org/BookChapter">
+          <header id="ct-chapter-top">
+              <button type="button" id="ct-tc-menu" onclick="openContents()" aria-label="Open Table of Contents"></button>
+              <div class="ct-holder" style="cursor:pointer;" onclick="openContents()">
+                  <!-- Chapter title -->
+                  <h1 id="ct-chapter-title" itemprop="name">The Mycorrhizals' Means</h1>
+                  <!-- Book title -->
+                  <p id="ct-book-title">
+        <span itemprop="isPartOf" itemscope itemtype="https://schema.org/Book">
+          <span itemprop="name">Tractatus Ayyew</span>
+        </span>
+                  </p>
+                  <!-- Authors and location -->
+                  <p id="ct-chap-location">Earthen Principle No. 5</p>
+                  <!-- Optional metadata -->
+                  <p id="ct-word-count"><i>Book Two | 2,307 words</i></p>
+              </div>
+              <meta itemprop="wordCount" content="2307">
+          </header>
+      </article>
 
 <!-- Page Title Section-->
 
@@ -339,7 +409,7 @@ display: none;
   <div id="up-arrow"></div>
 
 
-  <div id="ct-main">
+  <main id="ct-main">
 
 
 <!-- MAIN TEXT CONTENT of the Page
@@ -364,7 +434,9 @@ display: none;
 -->
 
 
-<div class="page-paragraph">
+  <article class="chapter-article" aria-labelledby="ct-chapter-title" data-chapter="5" data-title="The Mycorrhizals' Means" data-theme="Interconnection Awareness" style="margin-bottom: 120px;">
+    <section class="chapter-section lead-section" aria-labelledby="en-2-5-00">
+      <div class="page-paragraph">
   <div class="ct-chapter-quote" style="width:100%;margin-top:30px;">
       <span style="background-color:var(--nav-bar-accent);padding:0.1em 0.2em;" id="en-2-5-00">“Earth’s systems tend towards ever greater awareness of their interconnection.”</span>
       <div class="ct-quote-source" style="font-size:small;text-align:right;width:90%;">― Earthen Ethic no. 5
@@ -415,7 +487,9 @@ display: none;
       
        
       </div>
+    </section>
 
+    <section class="chapter-section" aria-labelledby="en-2-5-04">
       <div class="page-paragraph" id="en-2-5-04">
         <p>To begin, let us return one more time to Earth's primordial story.</p>
 
@@ -652,7 +726,9 @@ display: none;
      <br><br><br>
   
     
-  </div><!--closes page text content, then loads page curtains:-->
+    </section>
+  </article>
+  <!--closes page text content, then loads page curtains:-->
 
 
 
@@ -765,7 +841,7 @@ display: none;
 
    
           
-  </div><!--Closes main content block-->
+  </main><!--Closes main content block-->
 
 
 
@@ -837,4 +913,3 @@ display: none;
 </BODY>
 
 </HTML>
-


### PR DESCRIPTION
### Motivation

- Bring the awareness chapter up to the v2.1.1 landing template by refreshing metadata, social/structured data, asset preloads and stylesheet/script versioning.
- Improve semantic/SEO markup for the chapter by adding schema and article/section structure while preserving all original textual content.

### Description

- Updated `en/awareness.html` metadata (version string, `canonical`/alternate links, `keywords`, `author` encoding, `article:modified_time`, `ai-summary`, `provenance`, license and Open Graph details) to match the v2.1.1 template.
- Added JSON-LD `BookChapter` structured data for the chapter (authors, partOf Book, description, keywords, license, word count and URL).
- Replaced asset preloads and icon references to the awareness assets (`../svgs/12-awareness-*.svg`), bumped stylesheet and subscription script query versions and updated service worker registration to include `?v=1.4`.
- Introduced semantic layout: wrapped chapter content in `article`/`section`/`main` elements with `itemscope`/`itemtype` and `itemprop` attributes for improved accessibility and machine readability, and added `meta itemprop="wordCount"`.
- Minor script/include attribute adjustments (removed `async` from dark-mode module, updated `includes/content-curtain.js` to `?v=3.1`), and preserved all textual content exactly as requested.

### Testing

- Served the site locally with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/en/awareness.html` using Playwright to verify render and capture a visual snapshot, producing `artifacts/awareness-v2-1-1.png` (succeeded).
- No automated unit tests were added or required for this HTML/markup update. All changes were validated by the rendered screenshot and a local smoke-check of the modified page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698057353fbc832bbfc80f843f745848)